### PR TITLE
Switch login to M3U playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# IPTV Player for Xtream Codes
+# IPTV Player for M3U Playlists
 
-This is a simple Python GUI application for macOS (including Apple Silicon) that connects to an Xtream Codes IPTV server, lists available bouquets (groups), allows searching channels and opens streams with the default video player.
+This is a simple Python GUI application for macOS (including Apple Silicon) that loads an M3U playlist, lists available bouquets (groups), allows searching channels and opens streams with the default video player.
 
 ## Requirements
 
@@ -14,7 +14,7 @@ This is a simple Python GUI application for macOS (including Apple Silicon) that
 python3 iptv_player.py
 ```
 
-On startup, enter the server URL (without trailing slash), your username and password. After successful login, select a bouquet, search for channels, and double-click a channel to play it.
+On startup, enter the URL or path to an M3U playlist. After the playlist is loaded, select a bouquet, search for channels, and double-click a channel to play it.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # IPTV Player for M3U Playlists
 
-This is a simple Python GUI application for macOS (including Apple Silicon) that loads an M3U playlist, lists available bouquets (groups), allows searching channels and opens streams with the default video player.
+This is a simple Python GUI application for macOS (including Apple Silicon) that loads an M3U playlist, lists available bouquets (groups), allows searching channels and opens streams with VLC by default on macOS.
 
 ## Requirements
 
 - Python 3 with Tkinter (included with standard Python on macOS)
 - `requests` library (`pip install requests`)
-- A video player installed (e.g., VLC). Streams are opened using the default handler via the `open` command.
+- A video player installed (e.g., VLC). On macOS the streams are opened in VLC using `open -a VLC`; other platforms use the system default handler.
 
 ## Usage
 

--- a/iptv_player.py
+++ b/iptv_player.py
@@ -6,41 +6,37 @@ import subprocess
 import sys
 
 class LoginFrame(ttk.Frame):
+    """Frame asking for an M3U playlist."""
+
     def __init__(self, master, on_login):
         super().__init__(master)
         self.on_login = on_login
         self.columnconfigure(1, weight=1)
 
-        ttk.Label(self, text="Server URL (without trailing slash)").grid(row=0, column=0, sticky=tk.W)
-        self.server_var = tk.StringVar(value="http://")
-        ttk.Entry(self, textvariable=self.server_var).grid(row=0, column=1, sticky=tk.EW)
+        ttk.Label(self, text="M3U Playlist URL or Path").grid(row=0, column=0, sticky=tk.W)
+        self.playlist_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.playlist_var).grid(row=0, column=1, sticky=tk.EW)
 
-        ttk.Label(self, text="Username").grid(row=1, column=0, sticky=tk.W)
-        self.user_var = tk.StringVar()
-        ttk.Entry(self, textvariable=self.user_var).grid(row=1, column=1, sticky=tk.EW)
+        self.login_btn = ttk.Button(self, text="Load", command=self.load)
+        self.login_btn.grid(row=1, column=0, columnspan=2, pady=5)
 
-        ttk.Label(self, text="Password").grid(row=2, column=0, sticky=tk.W)
-        self.pass_var = tk.StringVar()
-        ttk.Entry(self, textvariable=self.pass_var, show="*").grid(row=2, column=1, sticky=tk.EW)
-
-        self.login_btn = ttk.Button(self, text="Login", command=self.login)
-        self.login_btn.grid(row=3, column=0, columnspan=2, pady=5)
-
-    def login(self):
-        server = self.server_var.get().strip()
-        user = self.user_var.get().strip()
-        passwd = self.pass_var.get().strip()
-        if not (server and user and passwd):
-            messagebox.showerror("Error", "Please enter server, username and password")
+    def load(self):
+        playlist = self.playlist_var.get().strip()
+        if not playlist:
+            messagebox.showerror("Error", "Please enter a playlist path or URL")
             return
         try:
-            playlist_url = f"{server}/get.php?username={user}&password={passwd}&type=m3u&output=ts"
-            resp = requests.get(playlist_url, timeout=10)
-            resp.raise_for_status()
+            if playlist.startswith("http://") or playlist.startswith("https://"):
+                resp = requests.get(playlist, timeout=10)
+                resp.raise_for_status()
+                text = resp.text
+            else:
+                with open(playlist, "r", encoding="utf-8") as fh:
+                    text = fh.read()
         except Exception as exc:
             messagebox.showerror("Error", f"Failed to load playlist: {exc}")
             return
-        self.on_login(resp.text)
+        self.on_login(text)
 
 class PlayerApp(tk.Tk):
     def __init__(self):

--- a/iptv_player.py
+++ b/iptv_player.py
@@ -133,7 +133,7 @@ class PlayerApp(tk.Tk):
     def _open_stream(self, url):
         try:
             if sys.platform == "darwin":
-                subprocess.Popen(['open', url])
+                subprocess.Popen(['open', '-a', 'VLC', url])
             elif sys.platform.startswith('win'):
                 os.startfile(url)
             else:

--- a/iptv_player.py
+++ b/iptv_player.py
@@ -4,6 +4,7 @@ import requests
 import re
 import subprocess
 import sys
+import os
 
 class LoginFrame(ttk.Frame):
     """Frame asking for an M3U playlist."""


### PR DESCRIPTION
## Summary
- update login page to load a local or remote M3U playlist
- document new workflow for loading playlists instead of username/password login

## Testing
- `python3 -m py_compile iptv_player.py`

------
https://chatgpt.com/codex/tasks/task_e_6843574b86748326bc956bb9883ea88e