### PR TITLE
Enhance playlist handling and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# IPTV Player for Xtream Codes
+# IPTV Player for M3U Playlists
 
-This is a simple Python GUI application for macOS (including Apple Silicon) that connects to an Xtream Codes IPTV server, lists available bouquets (groups), allows searching channels and opens streams with the default video player.
+This is a simple Python GUI application for macOS (including Apple Silicon) that loads an M3U playlist, lists available bouquets (groups), allows searching channels and opens streams with VLC by default on macOS.
 
 ## Requirements
 
 - Python 3 with Tkinter (included with standard Python on macOS)
 - `requests` library (`pip install requests`)
-- A video player installed (e.g., VLC). Streams are opened using the default handler via the `open` command.
+- A video player installed (e.g., VLC). On macOS the streams are opened in VLC using `open -a VLC`; other platforms use the system default handler.
 
 ## Usage
 
@@ -14,7 +14,7 @@ This is a simple Python GUI application for macOS (including Apple Silicon) that
 python3 iptv_player.py
 ```
 
-On startup, enter the server URL (without trailing slash), your username and password. After successful login, select a bouquet, search for channels, and double-click a channel to play it.
+On startup, choose or enter the URL/path to an M3U playlist. Previously used playlists are stored so you can easily pick them again. After the playlist is loaded a bouquet named **All Channels** is available for searching across the entire list. Double-click a channel to play it.
 
 ## Disclaimer
 

--- a/iptv_player.py
+++ b/iptv_player.py
@@ -1,52 +1,90 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk, messagebox, filedialog
 import requests
 import re
 import subprocess
 import sys
+import os
+import json
+from pathlib import Path
+
+PLAYLISTS_FILE = Path(__file__).with_name("playlists.json")
 
 class LoginFrame(ttk.Frame):
+    """Frame asking for an M3U playlist."""
+
     def __init__(self, master, on_login):
         super().__init__(master)
         self.on_login = on_login
         self.columnconfigure(1, weight=1)
 
-        ttk.Label(self, text="Server URL (without trailing slash)").grid(row=0, column=0, sticky=tk.W)
-        self.server_var = tk.StringVar(value="http://")
-        ttk.Entry(self, textvariable=self.server_var).grid(row=0, column=1, sticky=tk.EW)
+        ttk.Label(self, text="M3U Playlist URL or Path").grid(row=0, column=0, sticky=tk.W)
+        self.playlists = self._load_history()
+        self.playlist_var = tk.StringVar()
+        self.playlist_cb = ttk.Combobox(self, textvariable=self.playlist_var)
+        self.playlist_cb['values'] = self.playlists
+        self.playlist_cb.grid(row=0, column=1, sticky=tk.EW)
+        ttk.Button(self, text="Browse...", command=self._browse).grid(row=0, column=2, padx=5)
 
-        ttk.Label(self, text="Username").grid(row=1, column=0, sticky=tk.W)
-        self.user_var = tk.StringVar()
-        ttk.Entry(self, textvariable=self.user_var).grid(row=1, column=1, sticky=tk.EW)
+        self.login_btn = ttk.Button(self, text="Load", command=self.load)
+        self.login_btn.grid(row=1, column=0, columnspan=3, pady=5)
 
-        ttk.Label(self, text="Password").grid(row=2, column=0, sticky=tk.W)
-        self.pass_var = tk.StringVar()
-        ttk.Entry(self, textvariable=self.pass_var, show="*").grid(row=2, column=1, sticky=tk.EW)
+    def _browse(self):
+        path = filedialog.askopenfilename(filetypes=[('M3U files', '*.m3u'), ('All files', '*')])
+        if path:
+            self.playlist_var.set(path)
 
-        self.login_btn = ttk.Button(self, text="Login", command=self.login)
-        self.login_btn.grid(row=3, column=0, columnspan=2, pady=5)
+    def _load_history(self):
+        if PLAYLISTS_FILE.exists():
+            try:
+                with open(PLAYLISTS_FILE, 'r', encoding='utf-8') as fh:
+                    return json.load(fh)
+            except Exception:
+                return []
+        return []
 
-    def login(self):
-        server = self.server_var.get().strip()
-        user = self.user_var.get().strip()
-        passwd = self.pass_var.get().strip()
-        if not (server and user and passwd):
-            messagebox.showerror("Error", "Please enter server, username and password")
+    def _save_history(self):
+        if self.playlist_var.get() not in self.playlists:
+            self.playlists.append(self.playlist_var.get())
+            try:
+                with open(PLAYLISTS_FILE, 'w', encoding='utf-8') as fh:
+                    json.dump(self.playlists, fh)
+            except Exception:
+                pass
+            self.playlist_cb['values'] = self.playlists
+
+    def load(self):
+        playlist = self.playlist_var.get().strip()
+        if not playlist:
+            messagebox.showerror("Error", "Please enter a playlist path or URL")
             return
         try:
-            playlist_url = f"{server}/get.php?username={user}&password={passwd}&type=m3u&output=ts"
-            resp = requests.get(playlist_url, timeout=10)
-            resp.raise_for_status()
+            if playlist.startswith("http://") or playlist.startswith("https://"):
+                resp = requests.get(playlist, timeout=10)
+                resp.raise_for_status()
+                text = resp.text
+            else:
+                with open(playlist, "r", encoding="utf-8") as fh:
+                    text = fh.read()
         except Exception as exc:
             messagebox.showerror("Error", f"Failed to load playlist: {exc}")
             return
-        self.on_login(resp.text)
+        self._save_history()
+        self.on_login(text)
 
 class PlayerApp(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("IPTV Player")
         self.geometry("700x500")
+        style = ttk.Style(self)
+        try:
+            style.theme_use('clam')
+        except Exception:
+            pass
+        style.configure('TLabel', font=('Helvetica', 11))
+        style.configure('TButton', font=('Helvetica', 11))
+        style.configure('TEntry', font=('Helvetica', 11))
         self.playlist = []
         self.groups = {}
         self._show_login()
@@ -80,6 +118,7 @@ class PlayerApp(tk.Tk):
         groups = {}
         for entry in entries:
             groups.setdefault(entry['group'], []).append(entry)
+        groups['All Channels'] = entries
         self.groups = groups
         return entries
 
@@ -92,7 +131,10 @@ class PlayerApp(tk.Tk):
         ttk.Label(top_frame, text="Bouquet:").pack(side=tk.LEFT)
         self.group_var = tk.StringVar()
         group_cb = ttk.Combobox(top_frame, textvariable=self.group_var, state="readonly")
-        group_cb['values'] = sorted(self.groups)
+        groups = sorted(self.groups)
+        if 'All Channels' in groups:
+            groups.insert(0, groups.pop(groups.index('All Channels')))
+        group_cb['values'] = groups
         group_cb.pack(side=tk.LEFT, padx=5)
         if group_cb['values']:
             self.group_var.set(group_cb['values'][0])
@@ -136,7 +178,7 @@ class PlayerApp(tk.Tk):
     def _open_stream(self, url):
         try:
             if sys.platform == "darwin":
-                subprocess.Popen(['open', url])
+                subprocess.Popen(['open', '-a', 'VLC', url])
             elif sys.platform.startswith('win'):
                 os.startfile(url)
             else:


### PR DESCRIPTION
## Summary
- remember previously used playlists and offer them in a dropdown
- add an **All Channels** bouquet for searching across the entire playlist
- tweak the look with the `clam` theme and better fonts

## Testing
- `python3 -m py_compile iptv_player.py`


------
https://chatgpt.com/codex/tasks/task_e_6843574b86748326bc956bb9883ea88e